### PR TITLE
Try to fix Windows CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,12 +20,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Set OPENSSL_DIR for Windows
       if: startsWith(matrix.os, 'windows')
-      run: |
-        DIR C:\
-        DIR "C:\Program Files"
-        DIR "C:\Program Files\OpenSSL"
-        DIR "C:\vcpkg"
-        echo "OPENSSL_DIR=C:\Program Files\OpenSSL" >> $env:GITHUB_ENV
+      run: echo "OPENSSL_DIR=C:\Program Files\OpenSSL" >> $env:GITHUB_ENV
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
-jobs:            
+jobs:
   build:
     strategy:
       matrix:
@@ -18,6 +18,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Set OPENSSL_DIR for Windows
+      if: startsWith(matrix.os, 'windows')
+      run: |
+        DIR C:\
+        DIR "C:\Program Files"
+        DIR "C:\Program Files\OpenSSL"
+        DIR "C:\vcpkg"
+        echo "OPENSSL_DIR=C:\Program Files\OpenSSL" >> $env:GITHUB_ENV
     - name: Build
       run: cargo build --verbose
     - name: Run tests


### PR DESCRIPTION
GitHub says [0] that OpenSSL is already installed, so we *shouldn't need to futz around with vcpkg, choco, etc to install that and slow things down further. But it could be installed to C:\OpenSSL, C:\OpenSSL-Win64, C:\Program Files\OpenSSL-Win64\, etc.