### PR TITLE
Add optional rustls crypto backend

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,3 +33,14 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+
+  build-rustls:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build securestore with rustls
+      run: cargo build -p securestore --no-default-features --features rustls --verbose
+    - name: Test securestore with rustls
+      run: cargo test -p securestore --no-default-features --features rustls --verbose
+    - name: Build ssclient with rustls
+      run: cargo build -p ssclient --no-default-features --features rustls --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,7 @@ members = [
 	"securestore",
 	"ssclient",
 ]
+
+# native rust pbkdf2/crypto are very slow w/out optimizations
+[profile.dev.package."*"]
+opt-level = 2

--- a/README.md
+++ b/README.md
@@ -15,6 +15,49 @@ This rust implementation of the SecureStore protocol ships in two separate, comp
 
 The typical workflow for deploying versioned secrets alongside a restricted-access binary (e.g. a web app, a kiosk, or similar where the application isn't distributed directly to end users and is running in what is considered to be a privileged environment) is demonstrated here.
 
+### Build features (crypto backends)
+
+Cryptography is provided by one of two backends, selected at build time via Cargo features:
+
+| Feature | Description |
+|--------|-------------|
+| **openssl** (default) | Uses the [OpenSSL] library (system or vendored). Requires OpenSSL to be installed or built. |
+| **rustls** | Pure-Rust backend (no OpenSSL). Uses `getrandom`, `aes`, `cbc`, `hmac`, `sha1`, `pbkdf2`, and `subtle`. Ideal when you want to avoid OpenSSL (e.g. Windows, musl, or cross-compilation). |
+
+- **Default:** both the `securestore` crate and `ssclient` use the **openssl** backend by default.
+- **Use rustls:** build with `--no-default-features --features rustls` to use the pure-Rust backend. No system OpenSSL or C toolchain is required.
+- **Vendored OpenSSL:** to statically link OpenSSL (e.g. for portable Linux binaries), use the **openssl-vendored** feature: `--features openssl-vendored`.
+
+Vaults created or decrypted with one backend are fully compatible with the other; the format and algorithms are the same.
+
+**Examples:**
+
+```sh
+# Default: OpenSSL (system or as needed)
+cargo build
+cargo install ssclient
+
+# Pure-Rust, no OpenSSL
+cargo build --no-default-features --features rustls
+cargo install ssclient --no-default-features --features rustls
+
+# Static OpenSSL for musl (e.g. Alpine)
+cargo build --target x86_64-unknown-linux-musl --features openssl-vendored
+```
+
+In `Cargo.toml`, depend on `securestore` with default features for OpenSSL, or opt into a backend explicitly:
+
+```toml
+[dependencies]
+# Default: OpenSSL
+securestore = "0.100"
+
+# Or pure-Rust (no OpenSSL)
+# securestore = { version = "0.100", default-features = false, features = ["rustls"] }
+```
+
+[OpenSSL]: https://www.openssl.org/
+
 ## Adding a SecureStore vault to your rust workspace
 
 Start by installing a copy of `ssclient`, the interactive SecureStore cli. Pre-built binaries are available (see releases), but the majority of rust developers will find the most convenient option for distribution to be direct installation via `cargo`:
@@ -210,6 +253,8 @@ edition = "2021"
 [dependencies]
 once_cell = "1.13.0"
 securestore = "0.100.0"
+# Optional: use the pure-Rust crypto backend (no OpenSSL)
+# securestore = { version = "0.100.0", default-features = false, features = ["rustls"] }
 ```
 
 After which we can open `src/main.rs` and add some code to open the secrets file and decrypt + retrieve one or more secrets at runtime. [The ssclient documentation](https://docs.rs/securestore/latest/securestore/) covers how the `securestore` crate and its primary `SecretsManager` type are used, but we'll demo the basics below.

--- a/README.md
+++ b/README.md
@@ -21,27 +21,28 @@ Cryptography is provided by one of two backends, selected at build time via Carg
 
 | Feature | Description |
 |--------|-------------|
-| **openssl** (default) | Uses the [OpenSSL] library (system or vendored). Requires OpenSSL to be installed or built. |
-| **rustls** | Pure-Rust backend (no OpenSSL). Uses `getrandom`, `aes`, `cbc`, `hmac`, `sha1`, `pbkdf2`, and `subtle`. Ideal when you want to avoid OpenSSL (e.g. Windows, musl, or cross-compilation). |
+| `openssl` (default) | Uses the [OpenSSL] library. Requires OpenSSL to be already installed. |
+| `openssl-vendored` | Builds and statically links against the [OpenSSL] library at build-time. Requires a C toolchain for the target platform. |
+| `rustls` | Pure Rust backend (no OpenSSL and no C toolchain). Uses `getrandom`, `aes`, `cbc`, `hmac`, `sha1`, `pbkdf2`, and `subtle` crates. Ideal when you want to avoid OpenSSL (e.g. Windows, musl, or cross-compilation). |
 
-- **Default:** both the `securestore` crate and `ssclient` use the **openssl** backend by default.
-- **Use rustls:** build with `--no-default-features --features rustls` to use the pure-Rust backend. No system OpenSSL or C toolchain is required.
+- **Default:** both the `securestore` crate and `ssclient` use the **OpenSSL** backend by default.
 - **Vendored OpenSSL:** to statically link OpenSSL (e.g. for portable Linux binaries), use the **openssl-vendored** feature: `--features openssl-vendored`.
+- **Native Rust:** build with `--no-default-features --features rustls` to use the pure Rust backend. No system OpenSSL or C toolchain is required.
 
-Vaults created or decrypted with one backend are fully compatible with the other; the format and algorithms are the same.
+Vaults created or decrypted with one backend are fully compatible with one another; the store format and algorithms are the same.
 
 **Examples:**
 
 ```sh
-# Default: OpenSSL (system or as needed)
+# Default, requiring OpenSSL:
 cargo build
 cargo install ssclient
 
-# Pure-Rust, no OpenSSL
+# Pure-Rust, no OpenSSL dependency:
 cargo build --no-default-features --features rustls
 cargo install ssclient --no-default-features --features rustls
 
-# Static OpenSSL for musl (e.g. Alpine)
+# Static OpenSSL builds, e.g. for musl or Alpine:
 cargo build --target x86_64-unknown-linux-musl --features openssl-vendored
 ```
 
@@ -49,11 +50,14 @@ In `Cargo.toml`, depend on `securestore` with default features for OpenSSL, or o
 
 ```toml
 [dependencies]
-# Default: OpenSSL
+# Default (requires OpenSSL to be already installed):
 securestore = "0.100"
 
-# Or pure-Rust (no OpenSSL)
+# Pure-Rust (no OpenSSL or other system dependencies):
 # securestore = { version = "0.100", default-features = false, features = ["rustls"] }
+
+# Building OpenSSL from source:
+# securestore = { version = "0.100", features = ["openssl-vendored"] }
 ```
 
 [OpenSSL]: https://www.openssl.org/

--- a/securestore/Cargo.toml
+++ b/securestore/Cargo.toml
@@ -15,19 +15,47 @@ radix64 = "0.6.2"
 serde = { version = "1.0.197", features = [ "derive" ] }
 serde_json = "1.0.114"
 
-[target.'cfg(not(windows))'.dependencies.openssl]
-version = "0.10.64"
-features = [ ]
+[target.'cfg(not(windows))'.dependencies]
+openssl = { version = "0.10.64", optional = true }
 
-[target.'cfg(windows)'.dependencies.openssl]
-version = "0.10.64"
+[target.'cfg(windows)'.dependencies]
 # Building OpenSSL (via openssl/vendored) requires perl.exe on Windows, which
 # is less likely to be installed than OpenSSL itself.
-# features = [ "vendored" ]
+openssl = { version = "0.10.64", optional = true }
+
+[dependencies.getrandom]
+version = "0.2"
+optional = true
+
+[dependencies.aes]
+version = "0.8"
+optional = true
+
+[dependencies.cbc]
+version = "0.1"
+optional = true
+
+[dependencies.hmac]
+version = "0.12"
+optional = true
+
+[dependencies.sha1]
+version = "0.10"
+optional = true
+
+[dependencies.pbkdf2]
+version = "0.12"
+optional = true
+
+[dependencies.subtle]
+version = "2.5"
+optional = true
 
 [features]
-# default = [ "openssl-vendored" ]
+default = [ "openssl" ]
+openssl = [ "dep:openssl" ]
 openssl-vendored = [ "openssl/vendored" ]
+rustls = [ "dep:getrandom", "dep:aes", "dep:cbc", "dep:hmac", "dep:sha1", "dep:pbkdf2", "dep:subtle" ]
 
 [dev-dependencies]
 # `tempfile` is used in the tests to simplify cleanup

--- a/securestore/src/crypto/mod.rs
+++ b/securestore/src/crypto/mod.rs
@@ -1,0 +1,16 @@
+//! Internal crypto abstraction: one of OpenSSL or pure-Rust (rustls) backend.
+
+#[cfg(not(feature = "rustls"))]
+mod openssl_impl;
+#[cfg(not(feature = "rustls"))]
+use openssl_impl as backend;
+
+#[cfg(feature = "rustls")]
+mod rustls_impl;
+#[cfg(feature = "rustls")]
+use rustls_impl as backend;
+
+pub use backend::{
+    aes_128_cbc_decrypt, aes_128_cbc_encrypt, constant_time_eq, hmac_sha1, pbkdf2_hmac_sha1,
+    rand_bytes,
+};

--- a/securestore/src/crypto/openssl_impl.rs
+++ b/securestore/src/crypto/openssl_impl.rs
@@ -1,0 +1,47 @@
+//! OpenSSL-backed implementation of the internal crypto API.
+
+use crate::errors::Error;
+use openssl::hash::MessageDigest;
+use openssl::pkcs5::pbkdf2_hmac;
+use openssl::pkey::PKey;
+use openssl::rand;
+use openssl::sign::Signer;
+use openssl::symm::{self, Cipher};
+
+pub fn rand_bytes(buf: &mut [u8]) {
+    rand::rand_bytes(buf).expect("CSPRNG failure");
+}
+
+pub fn aes_128_cbc_encrypt(key: &[u8; 16], iv: &[u8; 16], plaintext: &[u8]) -> Vec<u8> {
+    let cipher = Cipher::aes_128_cbc();
+    symm::encrypt(cipher, key, Some(iv), plaintext).expect("AES-128-CBC encrypt failed")
+}
+
+pub fn aes_128_cbc_decrypt(
+    key: &[u8; 16],
+    iv: &[u8; 16],
+    ciphertext: &[u8],
+) -> Result<Vec<u8>, Error> {
+    let cipher = Cipher::aes_128_cbc();
+    symm::decrypt(cipher, key, Some(iv), ciphertext).map_err(Error::from)
+}
+
+pub fn hmac_sha1(key: &[u8; 16], data: &[u8]) -> [u8; 20] {
+    let pkey = PKey::hmac(key).expect("Failed to load HMAC key");
+    let mut signer =
+        Signer::new(MessageDigest::sha1(), &pkey).expect("Failed to create HMAC signer");
+    signer.update(data).expect("HMAC update failed");
+    let mut out = [0u8; 20];
+    let n = signer.sign(&mut out).expect("HMAC sign failed");
+    assert_eq!(n, 20);
+    out
+}
+
+pub fn pbkdf2_hmac_sha1(password: &[u8], salt: &[u8], rounds: u32, out: &mut [u8]) {
+    pbkdf2_hmac(password, salt, rounds as usize, MessageDigest::sha1(), out)
+        .expect("PBKDF2-HMAC-SHA1 failed");
+}
+
+pub fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    openssl::memcmp::eq(a, b)
+}

--- a/securestore/src/crypto/openssl_impl.rs
+++ b/securestore/src/crypto/openssl_impl.rs
@@ -26,11 +26,13 @@ pub fn aes_128_cbc_decrypt(
     symm::decrypt(cipher, key, Some(iv), ciphertext).map_err(Error::from)
 }
 
-pub fn hmac_sha1(key: &[u8; 16], data: &[u8]) -> [u8; 20] {
+pub fn hmac_sha1(key: &[u8; 16], chunks: &[&[u8]]) -> [u8; 20] {
     let pkey = PKey::hmac(key).expect("Failed to load HMAC key");
     let mut signer =
         Signer::new(MessageDigest::sha1(), &pkey).expect("Failed to create HMAC signer");
-    signer.update(data).expect("HMAC update failed");
+    for &chunk in chunks {
+        signer.update(chunk).expect("HMAC update failed");
+    }
     let mut out = [0u8; 20];
     let n = signer.sign(&mut out).expect("HMAC sign failed");
     assert_eq!(n, 20);

--- a/securestore/src/crypto/rustls_impl.rs
+++ b/securestore/src/crypto/rustls_impl.rs
@@ -1,0 +1,59 @@
+//! Pure-Rust (rustls-style) implementation of the internal crypto API.
+
+use crate::errors::{Error, ErrorKind};
+use aes::cipher::{block_padding::Pkcs7, BlockDecryptMut, BlockEncryptMut, KeyIvInit};
+use hmac::Mac;
+use pbkdf2::pbkdf2_hmac;
+use sha1::Sha1;
+use subtle::ConstantTimeEq;
+
+type Aes128CbcEnc = cbc::Encryptor<aes::Aes128>;
+type Aes128CbcDec = cbc::Decryptor<aes::Aes128>;
+
+pub fn rand_bytes(buf: &mut [u8]) {
+    getrandom::getrandom(buf).expect("CSPRNG failure");
+}
+
+pub fn aes_128_cbc_encrypt(key: &[u8; 16], iv: &[u8; 16], plaintext: &[u8]) -> Vec<u8> {
+    let mut buf = vec![0u8; plaintext.len() + 16];
+    let ct_len = Aes128CbcEnc::new(key.into(), iv.into())
+        .encrypt_padded_b2b_mut::<Pkcs7>(plaintext, &mut buf)
+        .expect("AES-128-CBC encrypt failed")
+        .len();
+    buf.truncate(ct_len);
+    buf
+}
+
+pub fn aes_128_cbc_decrypt(
+    key: &[u8; 16],
+    iv: &[u8; 16],
+    ciphertext: &[u8],
+) -> Result<Vec<u8>, Error> {
+    let mut buf = vec![0u8; ciphertext.len()];
+    let pt = Aes128CbcDec::new(key.into(), iv.into())
+        .decrypt_padded_b2b_mut::<Pkcs7>(ciphertext, &mut buf)
+        .map_err(|_| ErrorKind::DecryptionFailure)?;
+    Ok(pt.to_vec())
+}
+
+pub fn hmac_sha1(key: &[u8; 16], data: &[u8]) -> [u8; 20] {
+    let mut mac = hmac::Hmac::<Sha1>::new_from_slice(key).expect("HMAC key size");
+    mac.update(data);
+    let result = mac.finalize();
+    result.into_bytes().into()
+}
+
+pub fn pbkdf2_hmac_sha1(password: &[u8], salt: &[u8], rounds: u32, out: &mut [u8]) {
+    pbkdf2_hmac::<Sha1>(password, salt, rounds, out);
+}
+
+pub fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut eq = subtle::Choice::from(1u8);
+    for (x, y) in a.iter().zip(b.iter()) {
+        eq = eq & x.ct_eq(y);
+    }
+    eq.into()
+}

--- a/securestore/src/crypto/rustls_impl.rs
+++ b/securestore/src/crypto/rustls_impl.rs
@@ -36,9 +36,12 @@ pub fn aes_128_cbc_decrypt(
     Ok(pt.to_vec())
 }
 
-pub fn hmac_sha1(key: &[u8; 16], data: &[u8]) -> [u8; 20] {
-    let mut mac = hmac::Hmac::<Sha1>::new_from_slice(key).expect("HMAC key size");
-    mac.update(data);
+pub fn hmac_sha1(key: &[u8; 16], chunks: &[&[u8]]) -> [u8; 20] {
+    let mut mac =
+        hmac::Hmac::<Sha1>::new_from_slice(key).expect("Failed to init HMAC with provided key");
+    for &chunk in chunks {
+        mac.update(chunk);
+    }
     let result = mac.finalize();
     result.into_bytes().into()
 }

--- a/securestore/src/crypto/rustls_impl.rs
+++ b/securestore/src/crypto/rustls_impl.rs
@@ -51,12 +51,5 @@ pub fn pbkdf2_hmac_sha1(password: &[u8], salt: &[u8], rounds: u32, out: &mut [u8
 }
 
 pub fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    let mut eq = subtle::Choice::from(1u8);
-    for (x, y) in a.iter().zip(b.iter()) {
-        eq = eq & x.ct_eq(y);
-    }
-    eq.into()
+    a.ct_eq(b).into()
 }

--- a/securestore/src/crypto/rustls_impl.rs
+++ b/securestore/src/crypto/rustls_impl.rs
@@ -33,7 +33,9 @@ pub fn aes_128_cbc_decrypt(
     let pt = Aes128CbcDec::new(key.into(), iv.into())
         .decrypt_padded_b2b_mut::<Pkcs7>(ciphertext, &mut buf)
         .map_err(|_| ErrorKind::DecryptionFailure)?;
-    Ok(pt.to_vec())
+    let pt_len = pt.len();
+    buf.truncate(pt_len);
+    Ok(buf)
 }
 
 pub fn hmac_sha1(key: &[u8; 16], chunks: &[&[u8]]) -> [u8; 20] {

--- a/securestore/src/errors.rs
+++ b/securestore/src/errors.rs
@@ -101,6 +101,7 @@ impl std::convert::From<serde_json::Error> for Error {
     }
 }
 
+#[cfg(not(feature = "rustls"))]
 impl std::convert::From<openssl::error::ErrorStack> for Error {
     fn from(e: openssl::error::ErrorStack) -> Error {
         Error {

--- a/securestore/src/lib.rs
+++ b/securestore/src/lib.rs
@@ -66,6 +66,7 @@
 //!
 //! assert_eq!(db_password, String::from("pgsql123"));
 //! ```
+mod crypto;
 mod errors;
 mod serial;
 mod shared;
@@ -73,9 +74,9 @@ mod shared;
 mod tests;
 
 use self::shared::{CryptoKeys, EncryptedBlob, Vault};
+use crate::crypto::{pbkdf2_hmac_sha1, rand_bytes};
 pub use crate::errors::{Error, ErrorKind};
 pub use crate::serial::{BinaryDeserializable, BinarySerializable};
-use openssl::rand;
 use std::fs::File;
 use std::path::{Path, PathBuf};
 
@@ -212,7 +213,7 @@ const _: () = {
 impl SecretsManager {
     fn create_sentinel(keys: &CryptoKeys) -> EncryptedBlob {
         let mut random = [0u8; shared::IV_SIZE * 2];
-        rand::rand_bytes(&mut random).expect("Failed to create sentinel");
+        rand_bytes(&mut random);
         EncryptedBlob::encrypt(&keys, &random)
     }
 
@@ -481,7 +482,7 @@ impl<'a> KeySource<'a> {
         match &self {
             KeySource::Csprng => {
                 let mut buffer = [0u8; shared::KEY_COUNT * shared::KEY_LENGTH];
-                rand::rand_bytes(&mut buffer).expect("Key generation failure!");
+                rand_bytes(&mut buffer);
 
                 CryptoKeys::import(&buffer[..])
             }
@@ -496,17 +497,13 @@ impl<'a> KeySource<'a> {
             }
             KeySource::Buffer(buf) => CryptoKeys::import(&buf[..]),
             KeySource::Password(password) => {
-                use openssl::pkcs5::pbkdf2_hmac;
-
                 let mut key_data = [0u8; shared::KEY_COUNT * shared::KEY_LENGTH];
-                pbkdf2_hmac(
+                pbkdf2_hmac_sha1(
                     password.as_bytes(),
                     iv,
-                    shared::PBKDF2_ROUNDS,
-                    shared::PBKDF2_DIGEST(),
+                    shared::PBKDF2_ROUNDS as u32,
                     &mut key_data,
-                )
-                .expect("PBKDF2 key generation failed!");
+                );
 
                 CryptoKeys::import(&key_data[..])
             }

--- a/securestore/src/shared.rs
+++ b/securestore/src/shared.rs
@@ -1,9 +1,10 @@
 //! This (private) module contains code that must line up between the various
 //! implementations of SecureStore in different languages.
 
+use crate::crypto::{
+    aes_128_cbc_decrypt, aes_128_cbc_encrypt, constant_time_eq, hmac_sha1, rand_bytes,
+};
 use crate::errors::{Error, ErrorKind};
-use openssl::hash::MessageDigest;
-use openssl::rand;
 use radix64::STD as BASE64;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::BTreeMap;
@@ -18,11 +19,9 @@ pub const KEY_LENGTH: usize = 128 / 8;
 /// The number of rounds used for PBKDF2 key derivation. The resulting key is
 /// still considered to be a secret and is not stored!
 pub const PBKDF2_ROUNDS: usize = 256_000;
-/// The hash function used for PBKDF2, but only when password-based encryption/
-/// decryption is used. CSPRNG-derived symmetric keys are intentionally not
-/// stretched as their entropy may be constrained by the PBKDF2 digest, (at
-/// the cost of being vulnerable to a weekly seeded or compromised CSPRNG).
-pub const PBKDF2_DIGEST: fn() -> MessageDigest = MessageDigest::sha1;
+/// The hash function used for PBKDF2 is SHA1 (fixed by the SecureStore format).
+/// CSPRNG-derived symmetric keys are intentionally not stretched as their
+/// entropy may be constrained by the PBKDF2 digest.
 /// The size of an initialization vector in bytes
 pub const IV_SIZE: usize = KEY_LENGTH;
 /// The latest version of the vault schema
@@ -115,7 +114,7 @@ where
 impl Vault {
     pub fn new() -> Self {
         let mut iv = [0u8; IV_SIZE];
-        rand::rand_bytes(&mut iv).expect("IV generation failure!");
+        rand_bytes(&mut iv);
 
         Vault {
             version: SCHEMA_VERSION,
@@ -297,21 +296,13 @@ impl CryptoKeys {
     }
 }
 
-use openssl::pkey::PKey;
-use openssl::sign::Signer;
-use openssl::symm::{self, Cipher};
-
 impl EncryptedBlob {
     /// Creates an `EncryptedBlob` from a plaintext secret.
     pub fn encrypt<'a>(keys: &CryptoKeys, secret: &'a [u8]) -> EncryptedBlob {
-        let cipher = Cipher::aes_128_cbc();
         let mut iv = [0u8; KEY_LENGTH];
+        rand_bytes(&mut iv);
 
-        rand::rand_bytes(&mut iv).expect("Error reading IV bytes from RNG!");
-
-        // Unlike with decryption, we don't expect this to ever fail
-        let payload = symm::encrypt(cipher, &keys.encryption, Some(&iv), secret)
-            .expect("Error encrypting payload!");
+        let payload = aes_128_cbc_encrypt(&keys.encryption, &iv, secret);
 
         EncryptedBlob {
             hmac: Self::calculate_hmac(&keys.hmac, &iv, &payload),
@@ -327,36 +318,23 @@ impl EncryptedBlob {
             return ErrorKind::DecryptionFailure.into();
         }
 
-        let cipher = Cipher::aes_128_cbc();
-        let result = symm::decrypt(cipher, &keys.encryption, Some(&self.iv), &self.payload)?;
-
-        Ok(result)
+        aes_128_cbc_decrypt(&keys.encryption, &self.iv, &self.payload)
     }
 
     fn calculate_hmac(
-        &hmac_key: &[u8; KEY_LENGTH],
-        &iv: &[u8; IV_SIZE],
+        hmac_key: &[u8; KEY_LENGTH],
+        iv: &[u8; IV_SIZE],
         encrypted: &[u8],
     ) -> [u8; HMAC_SIZE] {
-        let key = PKey::hmac(&hmac_key).expect("Failed to load HMAC encryption key!");
-        let mut signer =
-            Signer::new(MessageDigest::sha1(), &key).expect("Failed to create HMAC signer!");
-
-        signer.update(&iv).unwrap();
-        signer.update(&encrypted).unwrap();
-
-        let mut hmac = [0u8; HMAC_SIZE];
-        signer
-            .sign(&mut hmac)
-            // NB: this is not the same as the HMAC not matching
-            .expect("Failed to create HMAC signature!");
-
-        hmac
+        let mut data = Vec::with_capacity(iv.len() + encrypted.len());
+        data.extend_from_slice(iv);
+        data.extend_from_slice(encrypted);
+        hmac_sha1(hmac_key, &data)
     }
 
     /// Authenticates the encrypted payload against the provided HMAC key
-    pub fn authenticate(&self, &hmac_key: &[u8; KEY_LENGTH]) -> bool {
-        let hmac = Self::calculate_hmac(&hmac_key, &self.iv, &self.payload);
-        openssl::memcmp::eq(&hmac, &self.hmac)
+    pub fn authenticate(&self, hmac_key: &[u8; KEY_LENGTH]) -> bool {
+        let hmac = Self::calculate_hmac(hmac_key, &self.iv, &self.payload);
+        constant_time_eq(&hmac, &self.hmac)
     }
 }

--- a/securestore/src/shared.rs
+++ b/securestore/src/shared.rs
@@ -326,10 +326,7 @@ impl EncryptedBlob {
         iv: &[u8; IV_SIZE],
         encrypted: &[u8],
     ) -> [u8; HMAC_SIZE] {
-        let mut data = Vec::with_capacity(iv.len() + encrypted.len());
-        data.extend_from_slice(iv);
-        data.extend_from_slice(encrypted);
-        hmac_sha1(hmac_key, &data)
+        hmac_sha1(hmac_key, &[iv, encrypted])
     }
 
     /// Authenticates the encrypted payload against the provided HMAC key

--- a/securestore/src/shared.rs
+++ b/securestore/src/shared.rs
@@ -18,10 +18,9 @@ pub const KEY_COUNT: usize = 2;
 pub const KEY_LENGTH: usize = 128 / 8;
 /// The number of rounds used for PBKDF2 key derivation. The resulting key is
 /// still considered to be a secret and is not stored!
+/// Note that CSPRNG-derived symmetric keys are intentionally not stretched as
+/// their entropy may be constrained by the PBKDF2 digest.
 pub const PBKDF2_ROUNDS: usize = 256_000;
-/// The hash function used for PBKDF2 is SHA1 (fixed by the SecureStore format).
-/// CSPRNG-derived symmetric keys are intentionally not stretched as their
-/// entropy may be constrained by the PBKDF2 digest.
 /// The size of an initialization vector in bytes
 pub const IV_SIZE: usize = KEY_LENGTH;
 /// The latest version of the vault schema

--- a/securestore/src/tests/encrypted_blob.rs
+++ b/securestore/src/tests/encrypted_blob.rs
@@ -1,5 +1,5 @@
+use crate::crypto::rand_bytes;
 use crate::shared::*;
-use openssl::rand;
 
 #[cfg(test)]
 impl Default for CryptoKeys {
@@ -7,8 +7,8 @@ impl Default for CryptoKeys {
         let mut encryption_key = [0u8; KEY_LENGTH];
         let mut hmac_key = [0u8; KEY_LENGTH];
 
-        rand::rand_bytes(&mut encryption_key).unwrap();
-        rand::rand_bytes(&mut hmac_key).unwrap();
+        rand_bytes(&mut encryption_key);
+        rand_bytes(&mut hmac_key);
 
         CryptoKeys {
             encryption: encryption_key,

--- a/securestore/src/tests/key_management.rs
+++ b/securestore/src/tests/key_management.rs
@@ -1,3 +1,4 @@
+use crate::crypto::rand_bytes;
 use crate::shared::*;
 use crate::*;
 use std::io::Read;
@@ -8,10 +9,10 @@ use tempfile::NamedTempFile;
 #[test]
 fn key_derivation_iv() {
     let mut iv1 = [0u8; IV_SIZE];
-    rand::rand_bytes(&mut iv1).unwrap();
+    rand_bytes(&mut iv1);
 
     let mut iv2 = [0u8; IV_SIZE];
-    rand::rand_bytes(&mut iv2).unwrap();
+    rand_bytes(&mut iv2);
 
     let derived1 = KeySource::Password("foo").extract_keys(&iv1).unwrap();
     let derived2 = KeySource::Password("foo").extract_keys(&iv1).unwrap();

--- a/ssclient/Cargo.toml
+++ b/ssclient/Cargo.toml
@@ -19,5 +19,8 @@ securestore = { path = "../securestore", version = "0.100.0", default-features =
 serde_json = "1.0.114"
 
 [features]
+default = [ "openssl" ]
+openssl = [ "securestore/openssl" ]
 # default = [ "openssl-vendored" ]
 openssl-vendored = [ "securestore/openssl-vendored" ]
+rustls = [ "securestore/rustls" ]


### PR DESCRIPTION
    Add optional rustls (pure-Rust) crypto backend
    
    SecureStore previously used OpenSSL for all cryptography (CSPRNG,
    AES-128-CBC, HMAC-SHA1, PBKDF2, constant-time comparison). That
    requires a system or vendored OpenSSL and can be awkward on Windows
    or when cross-compiling (e.g. musl).
    
    This change adds an optional backend implemented with pure-Rust crates
    (getrandom, aes, cbc, hmac, sha1, pbkdf2, subtle). The feature is
    named "rustls" to reflect a no-OpenSSL stack; the rustls TLS library
    itself is not used, as the SecureStore format needs AES-128-CBC and
    HMAC/PBKDF2 with SHA1, which are not exposed by rustls.
    
    - Default remains OpenSSL: default features enable the "openssl" backend.
    - New feature "rustls": use --no-default-features --features rustls to
      build without OpenSSL.
    - Internal crypto is abstracted in securestore/src/crypto/ with
      backend-specific modules (openssl_impl, rustls_impl) so the rest of
      the crate is backend-agnostic.
    - ssclient gains default = ["openssl"] and a "rustls" feature that
      forwards to securestore/rustls.
    - CI: add a build-rustls job that tests the rustls backend on Linux.
    
    Vaults created or decrypted with one backend are compatible with the
    other; both use the same algorithms and formats.
